### PR TITLE
validity check of IP address in Ethernet2

### DIFF
--- a/libraries/Ethernet2/src/Dns.cpp
+++ b/libraries/Ethernet2/src/Dns.cpp
@@ -60,7 +60,7 @@ int DNSClient::inet_aton(const char* aIPAddrString, IPAddress& aResult)
     // See if we've been given a valid IP address
     const char* p =aIPAddrString;
     while (*p &&
-           ( (*p == '.') || (*p >= '0') || (*p <= '9') ))
+           ( (*p == '.') || ((*p >= '0') && (*p <= '9')) ))
     {
         p++;
     }


### PR DESCRIPTION
The validity check of IP address in Dns.cpp in Ethernet2-Library is not working.
Simple fix: switch out || and &&.