### PR TITLE
Variables in SERCOM and SPI now protected, not private

### DIFF
--- a/hardware/arduino/samd/cores/arduino/SERCOM.h
+++ b/hardware/arduino/samd/cores/arduino/SERCOM.h
@@ -209,7 +209,7 @@ class SERCOM
 		int availableWIRE( void ) ;
 		uint8_t readDataWIRE( void ) ;
 
-	private:
+	protected:
 		Sercom* sercom;
 		uint8_t calculateBaudrateSynchronous(uint32_t baudrate) ;
 		uint32_t division(uint32_t dividend, uint32_t divisor) ;

--- a/hardware/arduino/samd/libraries/SPI/SPI.h
+++ b/hardware/arduino/samd/libraries/SPI/SPI.h
@@ -109,7 +109,7 @@ class SPIClass {
 	void setDataMode(uint8_t uc_mode);
 	void setClockDivider(uint16_t uc_div);
 
-  private:
+  protected:
 	SERCOM *_p_sercom;
 	uint8_t _uc_pinMiso;
 	uint8_t _uc_pinMosi;


### PR DESCRIPTION
A user can write a subclass to extend the SPI to use other pins or other characteristics. But to manipulate the hardware, the subclass needs to have access to structures in instance variables.